### PR TITLE
create key for test

### DIFF
--- a/test/key.h
+++ b/test/key.h
@@ -1,0 +1,22 @@
+#ifndef TEST_KEY_H_
+#define TEST_KEY_H_
+
+enum class TestKey{
+  Key01,
+  Key02,
+  Key03,
+  Key04,
+  Key05,
+  Key06,
+  Key07,
+  Key08,
+  Key09,
+  Key0a,
+  Key0b,
+  Key0c,
+  Key0d,
+  Key0e,
+  Key0f,
+  End,
+};
+#endif  // TEST_KEY_H_

--- a/test/structure.cpp
+++ b/test/structure.cpp
@@ -1,38 +1,30 @@
 #include <boost/test/unit_test.hpp>
 #include "binary_io/structure.hpp"
+#include "./key.h"
 
 namespace binary_io {
 BOOST_AUTO_TEST_SUITE(structure)
 // offset
 BOOST_AUTO_TEST_CASE(bit_offset_and_index) {
-  enum class Key {
-    Hoge,
-    Fuga,
-    Piyo,
-    End,
-  };
   using TestStructure = Structure<
-          Key,
-          Element<Key, Key::Hoge, 1, uint8_t>,
-          Element<Key, Key::Fuga, 3, uint8_t>,
-          Element<Key, Key::Piyo, 4, uint8_t>>;
+          TestKey,
+          Element<TestKey, TestKey::Key01, 1, uint8_t>,
+          Element<TestKey, TestKey::Key02, 3, uint8_t>,
+          Element<TestKey, TestKey::Key03, 4, uint8_t>>;
   // offset
-  BOOST_CHECK_EQUAL(TestStructure::bit_offset<Key::Hoge>(), 0);
-  BOOST_CHECK_EQUAL(TestStructure::bit_offset<Key::Fuga>(), 1);
-  BOOST_CHECK_EQUAL(TestStructure::bit_offset<Key::Piyo>(), 4);
+  BOOST_CHECK_EQUAL(TestStructure::bit_offset<TestKey::Key01>(), 0);
+  BOOST_CHECK_EQUAL(TestStructure::bit_offset<TestKey::Key02>(), 1);
+  BOOST_CHECK_EQUAL(TestStructure::bit_offset<TestKey::Key03>(), 4);
   BOOST_CHECK_EQUAL(TestStructure::bit_size(), 8);
   // index
-  BOOST_CHECK_EQUAL(TestStructure::element_index<Key::Hoge>(), 0);
-  BOOST_CHECK_EQUAL(TestStructure::element_index<Key::Fuga>(), 1);
-  BOOST_CHECK_EQUAL(TestStructure::element_index<Key::Piyo>(), 2);
+  BOOST_CHECK_EQUAL(TestStructure::element_index<TestKey::Key01>(), 0);
+  BOOST_CHECK_EQUAL(TestStructure::element_index<TestKey::Key02>(), 1);
+  BOOST_CHECK_EQUAL(TestStructure::element_index<TestKey::Key03>(), 2);
   BOOST_CHECK_EQUAL(TestStructure::element_size(), 3);
 }
 // empty
 BOOST_AUTO_TEST_CASE(empty) {
-  enum class Key {
-    End,
-  };
-  using TestStructure = Structure<Key>;
+  using TestStructure = Structure<TestKey>;
   BOOST_CHECK_EQUAL(TestStructure::bit_size(), 0);
   BOOST_CHECK_EQUAL(TestStructure::element_size(), 0);
 }


### PR DESCRIPTION
In gcc, "-fpermissive" error occurs when local enum class is used for
key of element.